### PR TITLE
Fix import paths in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ npm install geojson-equality-ts
 Use as either a class or function.
 
 ```typescript
-import { geojsonEquality, GeojsonEquality } from "geojson-equality";
+import { geojsonEquality, GeojsonEquality } from "geojson-equality-ts";
 
 // ... create g1 and g2 GeoJSON objects
 
@@ -28,7 +28,7 @@ eq.compare(g1, g2); // returns boolean
 In more detail.
 
 ```typescript
-const GeojsonEquality = require("geojson-equality");
+const GeojsonEquality = require("geojson-equality-ts");
 const eq = new GeojsonEquality();
 
 const g1: Polygon = {


### PR DESCRIPTION
Noticed when migrating to this package that the import paths in the readme are incorrect - this is a small patch to correct them. Cheers!